### PR TITLE
:wrench: Fix Make the tests ready to run

### DIFF
--- a/NavigationCodelab/app/build.gradle
+++ b/NavigationCodelab/app/build.gradle
@@ -110,6 +110,7 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$rootProject.espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$rootProject.espressoVersion"
     androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.2'
+    androidTestImplementation "androidx.test.ext:junit:$rootProject.testExtJunit"
 
     // Compose testing dependencies
     androidTestImplementation "androidx.compose.ui:ui-test:$rootProject.composeVersion"

--- a/TestingCodelab/app/build.gradle
+++ b/TestingCodelab/app/build.gradle
@@ -109,6 +109,7 @@ dependencies {
     androidTestImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$rootProject.espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$rootProject.espressoVersion"
+    androidTestImplementation "androidx.test.ext:junit:$rootProject.testExtJunit"
 
     // Compose testing dependencies
     androidTestImplementation "androidx.compose.ui:ui-test:$rootProject.composeVersion"


### PR DESCRIPTION
# The problem is happening

- I can't run the following two Codelab test codes.
  - [Testing in Jetpack Compose](https://t.co/968pK4DcHV) 
  - [Jetpack Compose Navigation](https://developer.android.com/codelabs/jetpack-compose-navigation?hl=ja&continue=https%3A%2F%2Fdeveloper.android.com%2Fcourses%2Fpathways%2Fcompose%3Fhl%3Dja%23codelab-https%3A%2F%2Fdeveloper.android.com%2Fcodelabs%2Fjetpack-compose-navigation#6)

# Solution

- Add the dependencies as described in [this post](https://github.com/googlecodelabs/android-compose-codelabs/issues/214#issuecomment-961222002).