### PR TITLE
Add compose compiler to kotlin deps for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,10 @@
   "packageRules": [
     {
       "groupName": "Kotlin Dependencies",
-      "matchPackagePrefixes": ["org.jetbrains.kotlin"]
+      "matchPackagePrefixes": [
+        "org.jetbrains.kotlin",
+        "^androidx.compose.compiler"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Compose compiler is tight with Kotlin version, so it should be updated with kotlin versions instead of all versions.