### PR TITLE
Fix readme for using Google Maps Key

### DIFF
--- a/AdvancedStateAndSideEffectsCodelab/README.md
+++ b/AdvancedStateAndSideEffectsCodelab/README.md
@@ -16,7 +16,7 @@ the [documentation says](https://developers.google.com/maps/documentation/androi
 and include it in the `local.properties` file as follows:
 
 ```
-google.maps.key={insert_your_api_key_here}
+MAPS_API_KEY={insert_your_api_key_here}
 ```
 
 When restricting the Key to Android apps, use `androidx.compose.samples.crane` as package name, and


### PR DESCRIPTION
The `google.maps.key` property name has been changed in the `build.gradle` script to `MAPS_API_KEY` and it should be reflected in the `README.md` file