### PR TITLE
fix: changed coroutine to Dispatchers.IO in function addPlantToGarden

### DIFF
--- a/MigrationCodelab/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModel.kt
+++ b/MigrationCodelab/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.samples.apps.sunflower.data.GardenPlantingRepository
 import com.google.samples.apps.sunflower.data.PlantRepository
 import com.google.samples.apps.sunflower.plantdetail.PlantDetailFragment
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 /**
@@ -36,7 +37,7 @@ class PlantDetailViewModel(
     val plant = plantRepository.getPlant(plantId)
 
     fun addPlantToGarden() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             gardenPlantingRepository.createGardenPlanting(plantId)
         }
     }


### PR DESCRIPTION
When I tried to add a plant to a garden, the app crashed (java.lang.IllegalStateException: Cannot access database on the main thread since it may potentially lock the UI for a long period of time.) because, in the function addPlantToGarden, the coroutine dispatcher uses Dispatchers.Main, and the correct usage is Dispatchers.IO for offloading blocking IO.