### PR TITLE
Remove regex character from compose compiler prefix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
       "groupName": "Kotlin Dependencies",
       "matchPackagePrefixes": [
         "org.jetbrains.kotlin",
-        "^androidx.compose.compiler"
+        "androidx.compose.compiler"
       ]
     }
   ]


### PR DESCRIPTION
Renovate doesn't correctly treat compose compiler as kotlin dependency.  Given this used to work, it's possible that they changed the implementation and it doesn't allow the regex chars anymore.