### PR TITLE
Use non-null View types on onCreateView

### DIFF
--- a/MigrationCodelab/app/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
+++ b/MigrationCodelab/app/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
@@ -41,7 +41,7 @@ class GardenFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         binding = FragmentGardenBinding.inflate(inflater, container, false)
         val adapter = GardenPlantingAdapter()
         binding.gardenList.adapter = adapter

--- a/MigrationCodelab/app/src/main/java/com/google/samples/apps/sunflower/HomeViewPagerFragment.kt
+++ b/MigrationCodelab/app/src/main/java/com/google/samples/apps/sunflower/HomeViewPagerFragment.kt
@@ -34,7 +34,7 @@ class HomeViewPagerFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         val binding = FragmentViewPagerBinding.inflate(inflater, container, false)
         val tabLayout = binding.tabs
         val viewPager = binding.viewPager

--- a/MigrationCodelab/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
+++ b/MigrationCodelab/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
@@ -40,7 +40,7 @@ class PlantListFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         val binding = FragmentPlantListBinding.inflate(inflater, container, false)
         context ?: return binding.root
 


### PR DESCRIPTION
No need to return nullable types if it's actually non-null, this eliminates warnings from IDE as well.

<img width="1047" alt="image" src="https://github.com/android/codelab-android-compose/assets/10363352/bdb117e9-405e-4feb-ab25-5960abae158f">
