### PR TITLE
Avoid exposing mutable state flows in UI

### DIFF
--- a/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyHomeViewModel.kt
+++ b/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyHomeViewModel.kt
@@ -23,6 +23,7 @@ import com.example.reply.data.EmailsRepository
 import com.example.reply.data.EmailsRepositoryImpl
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 
@@ -30,7 +31,7 @@ class ReplyHomeViewModel(private val emailsRepository: EmailsRepository = Emails
 
     // UI state exposed to the UI
     private val _uiState = MutableStateFlow(ReplyHomeUIState(loading = true))
-    val uiState: StateFlow<ReplyHomeUIState> = _uiState
+    val uiState: StateFlow<ReplyHomeUIState> = _uiState.asStateFlow()
 
     init {
         observeEmails()

--- a/ThemingCodelab/app/src/main/java/com/example/reply/ui/ReplyHomeViewModel.kt
+++ b/ThemingCodelab/app/src/main/java/com/example/reply/ui/ReplyHomeViewModel.kt
@@ -22,6 +22,7 @@ import com.example.reply.data.Email
 import com.example.reply.data.LocalEmailsDataProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 
@@ -29,7 +30,7 @@ class ReplyHomeViewModel : ViewModel() {
 
     // UI state exposed to the UI
     private val _uiState = MutableStateFlow(ReplyHomeUIState(loading = true))
-    val uiState: StateFlow<ReplyHomeUIState> = _uiState
+    val uiState: StateFlow<ReplyHomeUIState> = _uiState.asStateFlow()
 
     init {
         initEmailList()


### PR DESCRIPTION
We can convert `MutableStateFlow` to `ReadonlyStateFlow` as public APIs.