### PR TITLE
Replace enum values with entries

### DIFF
--- a/TestingCodelab/app/src/androidTest/java/com/example/compose/rally/TopAppBarTest.kt
+++ b/TestingCodelab/app/src/androidTest/java/com/example/compose/rally/TopAppBarTest.kt
@@ -33,10 +33,9 @@ class TopAppBarTest {
 
     @Test
     fun rallyTopAppBarTest_currentTabSelected() {
-        val allScreens = RallyScreen.values().toList()
         composeTestRule.setContent {
             RallyTopAppBar(
-                allScreens = allScreens,
+                allScreens = RallyScreen.entries,
                 onTabSelected = { },
                 currentScreen = RallyScreen.Accounts
             )
@@ -49,10 +48,9 @@ class TopAppBarTest {
 
     @Test
     fun rallyTopAppBarTest_currentLabelExists() {
-        val allScreens = RallyScreen.values().toList()
         composeTestRule.setContent {
             RallyTopAppBar(
-                allScreens = allScreens,
+                allScreens = RallyScreen.entries,
                 onTabSelected = { },
                 currentScreen = RallyScreen.Accounts
             )

--- a/TestingCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
+++ b/TestingCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
@@ -47,12 +47,11 @@ class RallyActivity : ComponentActivity() {
 @Composable
 fun RallyApp() {
     RallyTheme {
-        val allScreens = RallyScreen.values().toList()
         var currentScreen by rememberSaveable { mutableStateOf(RallyScreen.Overview) }
         Scaffold(
             topBar = {
                 RallyTopAppBar(
-                    allScreens = allScreens,
+                    allScreens = RallyScreen.entries,
                     onTabSelected = { screen -> currentScreen = screen },
                     currentScreen = currentScreen
                 )


### PR DESCRIPTION
`Enum.values()` is recommended to be replaced by `Enum.entries` since 1.9.