### PR TITLE
Fix for issue #376: Fix tab highlighting for Single Account navigation

### DIFF
--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
@@ -49,7 +49,11 @@ fun RallyApp() {
         val currentBackStack by navController.currentBackStackEntryAsState()
         val currentDestination = currentBackStack?.destination
         val currentScreen =
-            rallyTabRowScreens.find { it.route == currentDestination?.route } ?: Overview
+            rallyTabRowScreens.find {
+                it.route == currentDestination?.route || (it == Accounts && currentDestination?.route?.startsWith(
+                    SingleAccount.route
+                ) == true)
+            } ?: Overview
 
         Scaffold(
             topBar = {


### PR DESCRIPTION
**Title:** This pull request fixes issue #376  on the `end` branch by updating the logic in `RallyActivity.kt` to handle the edge case described in the issue.

**Description:**
This pull request addresses an issue where the `Accounts` tab was not highlighted when navigating to a specific single account page in the `end` version of the code.

**Changes Made:**
- Updated the logic to determine the current screen by adding a condition that checks if the current route starts with `single_account`.

```kotlin
val currentScreen = rallyTabRowScreens.find { it.route == currentDestination?.route || (it == Accounts && currentDestination?.route?.startsWith(SingleAccount.route) == true) } ?: Overview
```

**Explanation:**
When navigating to a single account, the page's route can be `single_account/Checking`, `single_account/Home Savings`, or `single_account/Car Savings`. These routes do not match the predefined tab routes (`overview`, `accounts`, `bills`), causing the original code to fall back to the `Overview` page.

The fix adds a condition to highlight the `Accounts` tab if the current route starts with `single_account`, ensuring the correct tab is highlighted.

I hope this resolves the issue effectively. If there are any questions or further changes needed, please let me know.
