### PR TITLE
Make the Adaptive Layout Codelab edge-to-edge

### DIFF
--- a/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/MainActivity.kt
+++ b/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/MainActivity.kt
@@ -16,9 +16,11 @@
 
 package com.example.reply.ui
 
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -33,6 +35,11 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        enableEdgeToEdge()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        }
 
         setContent {
             ReplyTheme {

--- a/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
+++ b/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
@@ -21,8 +21,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContent
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -55,7 +59,10 @@ fun ReplyListPane(
     onEmailClick: (Email) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    LazyColumn(modifier = modifier.fillMaxWidth()) {
+    LazyColumn(
+        modifier = modifier.fillMaxWidth(),
+        contentPadding = WindowInsets.safeDrawing.asPaddingValues()
+    ) {
         item {
             ReplySearchBar(modifier = Modifier.fillMaxWidth())
         }
@@ -73,7 +80,10 @@ fun ReplyDetailPane(
     email: Email,
     modifier: Modifier = Modifier
 ) {
-    LazyColumn(modifier = modifier.fillMaxWidth()) {
+    LazyColumn(
+        modifier = modifier.fillMaxWidth(),
+        contentPadding = WindowInsets.safeDrawing.asPaddingValues()
+    ) {
         item {
             ReplyEmailThreadItem(email)
         }
@@ -156,13 +166,13 @@ fun ReplyEmailThreadItem(
     modifier: Modifier = Modifier
 ) {
     Card(
-        modifier = modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        modifier = modifier.padding(horizontal = 16.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(20.dp)
+                .padding(horizontal = 20.dp)
         ) {
             Row(modifier = Modifier.fillMaxWidth()) {
                 ReplyProfileImage(
@@ -264,7 +274,7 @@ fun ReplySearchBar(modifier: Modifier = Modifier) {
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(16.dp)
+            .padding(horizontal = 16.dp)
             .background(MaterialTheme.colorScheme.surface, CircleShape),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
+++ b/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
@@ -20,12 +20,14 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeContent
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -46,9 +48,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.example.reply.R
 import com.example.reply.data.Email
@@ -59,9 +65,12 @@ fun ReplyListPane(
     onEmailClick: (Email) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val layoutDirection = LocalLayoutDirection.current
+
     LazyColumn(
         modifier = modifier.fillMaxWidth(),
         contentPadding = WindowInsets.safeDrawing.asPaddingValues()
+            .copy(layoutDirection, bottom = 0.dp)
     ) {
         item {
             ReplySearchBar(modifier = Modifier.fillMaxWidth())
@@ -301,3 +310,17 @@ fun ReplySearchBar(modifier: Modifier = Modifier) {
         )
     }
 }
+
+private fun PaddingValues.copy(
+    layoutDirection: LayoutDirection,
+    start: Dp? = null,
+    top: Dp? = null,
+    end: Dp? = null,
+    bottom: Dp? = null,
+) = PaddingValues(
+    start = start ?: calculateStartPadding(layoutDirection),
+    top = top ?: calculateTopPadding(),
+    end = end ?: calculateEndPadding(layoutDirection),
+    bottom = bottom ?: calculateBottomPadding(),
+)
+

--- a/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
+++ b/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
@@ -89,9 +89,14 @@ fun ReplyDetailPane(
     email: Email,
     modifier: Modifier = Modifier
 ) {
+
+    val layoutDirection = LocalLayoutDirection.current
+
     LazyColumn(
         modifier = modifier.fillMaxWidth(),
         contentPadding = WindowInsets.safeDrawing.asPaddingValues()
+            .copy(layoutDirection = layoutDirection, bottom = 0.dp)
+
     ) {
         item {
             ReplyEmailThreadItem(email)

--- a/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
+++ b/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
@@ -23,10 +23,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
@@ -65,12 +67,11 @@ fun ReplyListPane(
     onEmailClick: (Email) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val layoutDirection = LocalLayoutDirection.current
 
     LazyColumn(
         modifier = modifier.fillMaxWidth(),
-        contentPadding = WindowInsets.safeDrawing.asPaddingValues()
-            .copy(layoutDirection, bottom = 0.dp)
+        contentPadding = WindowInsets.safeDrawing.only(
+            WindowInsetsSides.Horizontal + WindowInsetsSides.Top).asPaddingValues()
     ) {
         item {
             ReplySearchBar(modifier = Modifier.fillMaxWidth())
@@ -94,9 +95,8 @@ fun ReplyDetailPane(
 
     LazyColumn(
         modifier = modifier.fillMaxWidth(),
-        contentPadding = WindowInsets.safeDrawing.asPaddingValues()
-            .copy(layoutDirection = layoutDirection, bottom = 0.dp)
-
+        contentPadding = WindowInsets.safeDrawing.only(
+            WindowInsetsSides.Horizontal + WindowInsetsSides.Top).asPaddingValues()
     ) {
         item {
             ReplyEmailThreadItem(email)
@@ -315,17 +315,3 @@ fun ReplySearchBar(modifier: Modifier = Modifier) {
         )
     }
 }
-
-private fun PaddingValues.copy(
-    layoutDirection: LayoutDirection,
-    start: Dp? = null,
-    top: Dp? = null,
-    end: Dp? = null,
-    bottom: Dp? = null,
-) = PaddingValues(
-    start = start ?: calculateStartPadding(layoutDirection),
-    top = top ?: calculateTopPadding(),
-    end = end ?: calculateEndPadding(layoutDirection),
-    bottom = bottom ?: calculateBottomPadding(),
-)
-

--- a/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/theme/Theme.kt
+++ b/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/theme/Theme.kt
@@ -16,7 +16,6 @@
 
 package com.example.reply.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -25,11 +24,7 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.ViewCompat
 
 // Material 3 color schemes
 private val replyDarkColorScheme = darkColorScheme(
@@ -103,13 +98,6 @@ fun ReplyTheme(
         }
         darkTheme -> replyDarkColorScheme
         else -> replyLightColorScheme
-    }
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            (view.context as Activity).window.statusBarColor = replyColorScheme.primary.toArgb()
-            ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme
-        }
     }
 
     MaterialTheme(


### PR DESCRIPTION
**MainActivity.kt**
+ Called `enableEdgeToEdge()`
+ Removed translucency applied to 3-button navigation bar with `isNavigationBarContrastEnforced=false`

**Theme.kt**
+ Removed all logic needed to set the status bar icon colors. Tested in both light & dark theme.

**ReplyListContent.kt**
+ Added a new function to make a copy of PaddingValues. Used in the next bullet.
+ Ensured first and last list items do not hide behind status bars, items scroll under the status bars, and excess bottom padding is removed in `ReplyListPane` and `ReplyDetailPane`. To do this, I set `contentPadding` = `WindowInsets.safeDrawing.asPaddingValues().copy(layoutDirection, bottom = 0.dp)`.
+ Now that we're accounting for the top system bars, removed excess top padding by replacing `padding(16.dp)` with `padding(horizontal = 16.dp)`.

**These changes are made to the `main` branch.**

Portrait:
![Screenshot_20240829-155943](https://github.com/user-attachments/assets/dd0d2f2a-a800-4b34-b355-ba8e149ce564)

Landscape (looks a little weird, not yet sure what to do about this):
![Screenshot_20240829-160014](https://github.com/user-attachments/assets/37ecbac0-41c9-4606-91a9-1ac1c14e5deb)

Unfolded, showing the last list item:
![Screenshot_20240829-162448](https://github.com/user-attachments/assets/da596d81-b9c8-4278-8558-572a1f5c8865)

**When this commit is cherry picked to the `end` branch the app will look like this:**
![Screenshot_20240829-163202](https://github.com/user-attachments/assets/63fc97d6-9a20-4e1d-b44a-3ee498cbfa9c)
