### PR TITLE
Use isSystemInDarkTheme as default value in Theming Codelab and preview function name

### DIFF
--- a/ThemingCodelab/app/src/main/java/com/example/reply/ui/MainActivity.kt
+++ b/ThemingCodelab/app/src/main/java/com/example/reply/ui/MainActivity.kt
@@ -60,7 +60,7 @@ class MainActivity : ComponentActivity() {
     name = "DefaultPreviewLight"
 )
 @Composable
-fun ReplyAppPreviewLight() {
+fun ReplyAppPreview() {
     ReplyApp(
         replyHomeUIState = ReplyHomeUIState(
             emails = LocalEmailsDataProvider.allEmails

--- a/ThemingCodelab/app/src/main/java/com/example/reply/ui/theme/Theme.kt
+++ b/ThemingCodelab/app/src/main/java/com/example/reply/ui/theme/Theme.kt
@@ -16,6 +16,7 @@
 
 package com.example.reply.ui.theme
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
@@ -37,7 +38,7 @@ private val LightColorScheme = lightColorScheme(
 
 @Composable
 fun ReplyTheme(
-    darkTheme: Boolean = false,
+    darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
     val replyColorScheme = when {


### PR DESCRIPTION
Currently the starting point for [Theming Codelab](https://developer.android.com/codelabs/jetpack-compose-theming) has default value for checking dark theme set to `false` instead of `isSystemInDarkTheme()`

It doesn't seem intentional for me and can be confusing for beginners 

Also - the name for preview function is `ReplyAppPreviewLight` even though it generates preview for both Dark and Light themes
`ReplyAppPreview` seems more fitting