### PR TITLE
Update renovate configuration to also check Google Maven repository.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,9 @@
       "matchPackagePrefixes": [
         "org.jetbrains.kotlin",
         "androidx.compose.compiler"
-      ]
+      ],
+      "matchDatasources": ["maven"],
+      "registryUrls": ["https://dl.google.com/dl/android/maven2/", "https://repo.maven.apache.org/maven2/"]
     }
   ]
 }


### PR DESCRIPTION
This solves cases in which the Central Maven repository is behind on certain Androidx libraries, which we want to update right as they are published.